### PR TITLE
Updated critical dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   },
   "dependencies": {
     "lodash": "^4.17.0",
-    "tunnel": "^0.0.4"
+    "tunnel": "^0.0.5"
   },
   "devDependencies": {
     "mocha": "^3.2.0",
     "goinstant-assert": "^1.1.1",
-    "request": "^2.30.0",
+    "request": "^2.83.0",
     "sinon": "^2.1.0"
   },
   "scripts": {


### PR DESCRIPTION
For the development dependencies only `request` was updates because it introduced a vulnerability, sinon and mocha will take more effort to upgrade.