### PR TITLE
include a function to enable/disable proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The complete list of options to `globalTunnel.initialize`:
 - **sockets** - _(optional)_ maximum number of TCP sockets to use in each pool.
   There are two pools: one for HTTP and one for HTTPS.  Uses node's default (5)
   if falsy.
+- **proxyEnableFunction** - _(optional)_ a function to enable/disable proxy per request will be called with request option as first parameter. if this function return truthy the proxy will be activated for set call. if it returns falsy the proxy will be deactivated for the call.
 
 ## Variations
 

--- a/index.js
+++ b/index.js
@@ -80,7 +80,6 @@ function stringifyProxy(conf) {
 globalTunnel.isProxying = false;
 globalTunnel.proxyUrl = null;
 globalTunnel.proxyConfig = null;
-globalTunnel.proxyEnableFunction = null;
 
 function findEnvVarProxy() {
   var i;
@@ -135,7 +134,7 @@ function findEnvVarProxy() {
  * @param {int} [conf.sockets=5] Maximum number of TCP sockets to use in each pool. There are two different pools for HTTP and HTTPS
  * @param {object} [conf.httpsOptions] - HTTPS options
  */
-globalTunnel.initialize = function(conf, proxyEnableFunction) {
+globalTunnel.initialize = function(conf) {
   // Don't do anything if already proxying.
   // To change the settings `.end()` should be called first.
   if (globalTunnel.isProxying) {
@@ -200,8 +199,13 @@ globalTunnel.initialize = function(conf, proxyEnableFunction) {
 
     globalTunnel.isProxying = true;
     globalTunnel.proxyUrl = stringifyProxy(conf);
+
+    var proxyEnableFunction = conf.proxyEnableFunction;
+    conf.proxyEnableFunction = null;
     globalTunnel.proxyConfig = clone(conf);
-    globalTunnel.proxyEnableFunction = proxyEnableFunction;
+    globalTunnel.proxyConfig.proxyEnableFunction = proxyEnableFunction;
+    conf.proxyEnableFunction = proxyEnableFunction;
+
   } catch (e) {
     resetGlobals();
     throw e;
@@ -246,9 +250,9 @@ var _makeAgent = function(conf, innerProtocol, useCONNECT) {
   }
 
   if (outerProtocol === 'https:') {
-    return new agents.OuterHttpsAgent(opts);
+    return new agents.OuterHttpsAgent(opts, globalTunnel);
   }
-  return new agents.OuterHttpAgent(opts);
+  return new agents.OuterHttpAgent(opts, globalTunnel);
 };
 
 /**
@@ -281,7 +285,7 @@ globalTunnel._makeRequest = function(httpOrHttps, protocol) {
       options = clone(options);
     }
     
-    var doProxy = !globalTunnel.proxyEnableFunction || globalTunnel.proxyEnableFunction(options);
+    var doProxy = !globalTunnel.proxyConfig.proxyEnableFunction || globalTunnel.proxyConfig.proxyEnableFunction(options);
 
     // Respect the default agent provided by node's lib/https.js
     if (
@@ -290,6 +294,9 @@ globalTunnel._makeRequest = function(httpOrHttps, protocol) {
       options.host
     ) {
       options.agent = options._defaultAgent || (doProxy ? httpOrHttps.globalAgent : ORIGINALS[protocol].globalAgent);
+    }
+    else if(!doProxy && options.agent === httpOrHttps.globalAgent) {
+      options.agent = ORIGINALS[protocol].globalAgent;
     }
 
     if(doProxy) {
@@ -314,5 +321,4 @@ globalTunnel.end = function() {
   globalTunnel.isProxying = false;
   globalTunnel.proxyUrl = null;
   globalTunnel.proxyConfig = null;
-  globalTunnel.proxyEnableFunction = null;
 };

--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ function stringifyProxy(conf) {
 globalTunnel.isProxying = false;
 globalTunnel.proxyUrl = null;
 globalTunnel.proxyConfig = null;
+globalTunnel.proxyEnableFunction = null;
 
 function findEnvVarProxy() {
   var i;
@@ -134,7 +135,7 @@ function findEnvVarProxy() {
  * @param {int} [conf.sockets=5] Maximum number of TCP sockets to use in each pool. There are two different pools for HTTP and HTTPS
  * @param {object} [conf.httpsOptions] - HTTPS options
  */
-globalTunnel.initialize = function(conf) {
+globalTunnel.initialize = function(conf, proxyEnableFunction) {
   // Don't do anything if already proxying.
   // To change the settings `.end()` should be called first.
   if (globalTunnel.isProxying) {
@@ -200,6 +201,7 @@ globalTunnel.initialize = function(conf) {
     globalTunnel.isProxying = true;
     globalTunnel.proxyUrl = stringifyProxy(conf);
     globalTunnel.proxyConfig = clone(conf);
+    globalTunnel.proxyEnableFunction = proxyEnableFunction;
   } catch (e) {
     resetGlobals();
     throw e;
@@ -278,6 +280,8 @@ globalTunnel._makeRequest = function(httpOrHttps, protocol) {
     } else {
       options = clone(options);
     }
+    
+    var doProxy = !globalTunnel.proxyEnableFunction || globalTunnel.proxyEnableFunction(options);
 
     // Respect the default agent provided by node's lib/https.js
     if (
@@ -285,15 +289,17 @@ globalTunnel._makeRequest = function(httpOrHttps, protocol) {
       typeof options.createConnection !== 'function' &&
       options.host
     ) {
-      options.agent = options._defaultAgent || httpOrHttps.globalAgent;
+      options.agent = options._defaultAgent || (doProxy ? httpOrHttps.globalAgent : ORIGINALS[protocol].globalAgent);
     }
 
-    // Set the default port ourselves to prevent Node doing it based on the proxy agent protocol
-    if (options.protocol === 'https:' || (!options.protocol && protocol === 'https')) {
-      options.port = options.port || 443;
-    }
-    if (options.protocol === 'http:' || (!options.protocol && protocol === 'http')) {
-      options.port = options.port || 80;
+    if(doProxy) {
+      // Set the default port ourselves to prevent Node doing it based on the proxy agent protocol
+      if (options.protocol === 'https:' || (!options.protocol && protocol === 'https')) {
+        options.port = options.port || 443;
+      }
+      if (options.protocol === 'http:' || (!options.protocol && protocol === 'http')) {
+        options.port = options.port || 80;
+      }
     }
 
     return ORIGINALS[protocol].request.call(httpOrHttps, options, callback);
@@ -308,4 +314,5 @@ globalTunnel.end = function() {
   globalTunnel.isProxying = false;
   globalTunnel.proxyUrl = null;
   globalTunnel.proxyConfig = null;
+  globalTunnel.proxyEnableFunction = null;
 };

--- a/lib/agents.js
+++ b/lib/agents.js
@@ -12,9 +12,9 @@ var pick = require('lodash/pick');
 /**
  * Proxy some traffic over HTTP.
  */
-function OuterHttpAgent(opts) {
+function OuterHttpAgent(opts, globalTunnel) {
   HttpAgent.call(this, opts);
-  mixinProxying(this, opts.proxy);
+  mixinProxying(this, opts.proxy, globalTunnel);
 }
 util.inherits(OuterHttpAgent, HttpAgent);
 exports.OuterHttpAgent = OuterHttpAgent;
@@ -22,9 +22,9 @@ exports.OuterHttpAgent = OuterHttpAgent;
 /**
  * Proxy some traffic over HTTPS.
  */
-function OuterHttpsAgent(opts) {
+function OuterHttpsAgent(opts, globalTunnel) {
   HttpsAgent.call(this, opts);
-  mixinProxying(this, opts.proxy);
+  mixinProxying(this, opts.proxy, globalTunnel);
 }
 util.inherits(OuterHttpsAgent, HttpsAgent);
 exports.OuterHttpsAgent = OuterHttpsAgent;
@@ -33,7 +33,7 @@ exports.OuterHttpsAgent = OuterHttpsAgent;
  * Override createConnection and addRequest methods on the supplied agent.
  * http.Agent and https.Agent will set up createConnection in the constructor.
  */
-function mixinProxying(agent, proxyOpts) {
+function mixinProxying(agent, proxyOpts, globalTunnel) {
   agent.proxy = proxyOpts;
 
   var orig = pick(agent, 'createConnection', 'addRequest');
@@ -41,12 +41,20 @@ function mixinProxying(agent, proxyOpts) {
   // Make the tcp or tls connection go to the proxy, ignoring the
   // destination host:port arguments.
   agent.createConnection = function(port, host, options) {
-    return orig.createConnection.call(this, this.proxy.port, this.proxy.host, options);
+    var doProxy = !globalTunnel.proxyConfig.proxyEnableFunction || globalTunnel.proxyConfig.proxyEnableFunction();
+    return doProxy ? orig.createConnection.call(this, this.proxy.port, this.proxy.host, options) : 
+                     orig.createConnection.call(this, Array.prototype.slice.apply(arguments));
   };
 
   agent.addRequest = function(req, options) {
-    req.path =
-      this.proxy.innerProtocol + '//' + options.host + ':' + options.port + req.path;
-    return orig.addRequest.call(this, req, options);
+    var doProxy = !globalTunnel.proxyConfig.proxyEnableFunction || globalTunnel.proxyConfig.proxyEnableFunction();
+    if(doProxy) {
+      req.path =
+        this.proxy.innerProtocol + '//' + options.host + ':' + options.port + req.path;
+      return orig.addRequest.call(this, req, options);
+    }
+    else {
+      return orig.addRequest.call(this, Array.prototype.slice.apply(arguments));
+    }
   };
 }

--- a/test/index.js
+++ b/test/index.js
@@ -146,7 +146,7 @@ describe('global-proxy', function() {
     });
   });
 
-  function proxyEnabledTests(testParams) {
+  function proxyEnabledTests(conf, testParams) {
     function connected(innerProto) {
       var innerSecure = innerProto === 'https:';
 
@@ -159,12 +159,17 @@ describe('global-proxy', function() {
         sinon.assert.notCalled(tls.connect);
       }
 
-      sinon.assert.calledOnce(called);
-      if (typeof called.getCall(0).args[0] === 'object') {
-        sinon.assert.calledWith(called, sinon.match.has('port', testParams.port));
-        sinon.assert.calledWith(called, sinon.match.has('host', '10.2.3.4'));
-      } else {
-        sinon.assert.calledWith(called, testParams.port, '10.2.3.4');
+      if(testParams.proxyEnableFunction !== false) {
+        sinon.assert.calledOnce(called);
+        if (typeof called.getCall(0).args[0] === 'object') {
+          sinon.assert.calledWith(called, sinon.match.has('port', testParams.port));
+          sinon.assert.calledWith(called, sinon.match.has('host', '10.2.3.4'));
+        } else {
+          sinon.assert.calledWith(called, testParams.port, '10.2.3.4');
+        }
+      }
+      else {
+        sinon.assert.notCalled(called);
       }
 
       var isCONNECT =
@@ -173,31 +178,56 @@ describe('global-proxy', function() {
         var expectConnect = 'example.dev:' + (innerSecure ? 443 : 80);
         var whichAgent = innerSecure ? https.globalAgent : http.globalAgent;
 
-        sinon.assert.calledOnce(whichAgent.request);
-        sinon.assert.calledWith(whichAgent.request, sinon.match.has('method', 'CONNECT'));
-        sinon.assert.calledWith(
-          whichAgent.request,
-          sinon.match.has('path', expectConnect)
-        );
+        if(testParams.proxyEnableFunction !== false) {
+          sinon.assert.calledOnce(whichAgent.request);
+          sinon.assert.calledWith(whichAgent.request, sinon.match.has('method', 'CONNECT'));
+          sinon.assert.calledWith(
+            whichAgent.request,
+            sinon.match.has('path', expectConnect)
+          );
+        }
+        else {
+          sinon.assert.notCalled(whichAgent.request);
+        }
       } else {
-        sinon.assert.calledOnce(http.Agent.prototype.addRequest);
-        var req = http.Agent.prototype.addRequest.getCall(0).args[0];
+        if(testParams.proxyEnableFunction !== false) {
+          sinon.assert.calledOnce(http.Agent.prototype.addRequest);
+          var req = http.Agent.prototype.addRequest.getCall(0).args[0];
 
-        var method = req.method;
-        assert.equal(method, 'GET');
+          var method = req.method;
+          assert.equal(method, 'GET');
 
-        var path = req.path;
-        if (innerSecure) {
-          assert.match(path, new RegExp('^https://example\\.dev:443/'));
-        } else {
-          assert.match(path, new RegExp('^http://example\\.dev:80/'));
+          var path = req.path;
+          if (innerSecure) {
+            assert.match(path, new RegExp('^https://example\\.dev:443/'));
+          } else {
+            assert.match(path, new RegExp('^http://example\\.dev:80/'));
+          }
+        }
+        else {
+          sinon.assert.notCalled(http.Agent.prototype.addRequest);
         }
       }
     }
 
     var localSandbox;
+
+    before(function() {
+      localSandbox = localSandbox || sinon.createSandbox();
+      if(testParams.proxyEnableFunction === true) {
+        conf.proxyEnableFunction = localSandbox.stub().returns(true);
+      }
+      if(testParams.proxyEnableFunction === false) {
+        conf.proxyEnableFunction = localSandbox.stub().returns(false);
+      }
+      globalTunnel.initialize(conf);
+    });
+    after(function() {
+      globalTunnel.end();
+    });
+
     beforeEach(function() {
-      localSandbox = sinon.createSandbox();
+      localSandbox = localSandbox || sinon.createSandbox();
       if (testParams.connect === 'both') {
         localSandbox.spy(http.globalAgent, 'request');
       }
@@ -207,6 +237,7 @@ describe('global-proxy', function() {
     });
     afterEach(function() {
       localSandbox.restore();
+      localSandbox = null;
     });
 
     it('(got proxying set up)', function() {
@@ -214,33 +245,43 @@ describe('global-proxy', function() {
     });
 
     describe('with the request library', function() {
-      it('will proxy http requests', function(done) {
+      it('will' + (testParams.proxyEnableFunction === false ? ' not' : '') + ' proxy http requests', function(done) {
         assert.isTrue(globalTunnel.isProxying);
         var dummyCb = sinon.stub();
         request.get('http://example.dev/', dummyCb);
         setImmediate(function() {
           connected('http:');
-          sinon.assert.notCalled(globalHttpAgent.addRequest);
+          if(testParams.proxyEnableFunction !== false) {
+            sinon.assert.notCalled(globalHttpAgent.addRequest);
+          }
+          else {
+            sinon.assert.calledOnce(globalHttpAgent.addRequest);
+          }
           sinon.assert.notCalled(globalHttpsAgent.addRequest);
           done();
         });
       });
 
-      it('will proxy https requests', function(done) {
+      it('will' + (testParams.proxyEnableFunction === false ? ' not' : '') + ' proxy https requests', function(done) {
         assert.isTrue(globalTunnel.isProxying);
         var dummyCb = sinon.stub();
         request.get('https://example.dev/', dummyCb);
         setImmediate(function() {
           connected('https:');
           sinon.assert.notCalled(globalHttpAgent.addRequest);
-          sinon.assert.notCalled(globalHttpsAgent.addRequest);
+          if(testParams.proxyEnableFunction !== false) {
+            sinon.assert.notCalled(globalHttpsAgent.addRequest);
+          }
+          else {
+            sinon.assert.calledOnce(globalHttpsAgent.addRequest);
+          }
           done();
         });
       });
     });
 
     describe('using raw request interface', function() {
-      it('will proxy http requests', function() {
+      it('will' + (testParams.proxyEnableFunction === false ? ' not' : '') + ' proxy http requests', function() {
         var req = http.request(
           {
             method: 'GET',
@@ -252,11 +293,16 @@ describe('global-proxy', function() {
         req.end();
 
         connected('http:');
-        sinon.assert.notCalled(globalHttpAgent.addRequest);
+        if(testParams.proxyEnableFunction !== false) {
+          sinon.assert.notCalled(globalHttpAgent.addRequest);
+        }
+        else {
+          sinon.assert.calledOnce(globalHttpAgent.addRequest);
+        }
         sinon.assert.notCalled(globalHttpsAgent.addRequest);
       });
 
-      it('will proxy https requests', function() {
+      it('will' + (testParams.proxyEnableFunction === false ? ' not' : '') + ' proxy https requests', function() {
         var req = https.request(
           {
             method: 'GET',
@@ -269,7 +315,12 @@ describe('global-proxy', function() {
 
         connected('https:');
         sinon.assert.notCalled(globalHttpAgent.addRequest);
-        sinon.assert.notCalled(globalHttpsAgent.addRequest);
+        if(testParams.proxyEnableFunction !== false) {
+          sinon.assert.notCalled(globalHttpsAgent.addRequest);
+        }
+        else {
+          sinon.assert.calledOnce(globalHttpsAgent.addRequest);
+        }
       });
 
       it('request respects explicit agent param', function() {
@@ -323,13 +374,6 @@ describe('global-proxy', function() {
   }
 
   function enabledBlock(conf, testParams) {
-    before(function() {
-      globalTunnel.initialize(conf);
-    });
-    after(function() {
-      globalTunnel.end();
-    });
-
     testParams = assign(
       {
         port: conf && conf.port,
@@ -339,7 +383,23 @@ describe('global-proxy', function() {
       testParams
     );
 
-    proxyEnabledTests(testParams);
+    describe('no proxyEnableFunction', function() {
+      proxyEnabledTests(conf, testParams);
+    });
+    if(conf) {
+      describe('with proxyEnableFunction returning false (i.e. disabling proxy for this call)', function() {
+        var testParamsWithFalsyProxyEnableFunction = assign({
+          proxyEnableFunction: false
+        }, testParams);
+        proxyEnabledTests(conf, testParamsWithFalsyProxyEnableFunction);
+      });
+      describe('with proxyEnableFunction returning true (i.e. enabling proxy for this call)', function() {
+        var testParamsWithFalsyProxyEnableFunction = assign({
+          proxyEnableFunction: true
+        }, testParams);
+        proxyEnabledTests(conf, testParamsWithFalsyProxyEnableFunction);
+      });
+    }
   }
 
   describe('with http proxy in intercept mode', function() {


### PR DESCRIPTION
```
var globalTunnel = require('global-tunnel-ng');

globalTunnel.initialize({
  host: '10.0.0.10',
  port: 8080,
  proxyAuth: 'userId:password', // optional authentication
  sockets: 50 // optional pool size for each http and https
}, function(options) {
  return options.host.indexOf('google') >=0;  // enable proxy for only google requests
});
```